### PR TITLE
add header height to aside added title

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Educare</title>
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap"
       rel="stylesheet"

--- a/frontend/src/components/sidebar/sidebar.styled.js
+++ b/frontend/src/components/sidebar/sidebar.styled.js
@@ -4,7 +4,7 @@ export const SidebarStyled = styled.aside`
   position: absolute;
   background-color: ${(props) => props.theme.color.cerulean};
   width: 100%;
-  height: calc(100vh - 90px - 124px);
+  height: calc(100vh - 90px - 77px);
   font-family: inter;
   padding: 1rem;
   display: flex;


### PR DESCRIPTION
This pull request includes changes to the `frontend` directory to update the application title and adjust the sidebar height styling.

### UI Improvements:

* [`frontend/index.html`](diffhunk://#diff-959f9cada636604db33bc1ba82fed347457dcb032c37ac195b4343c5f0ea6e72L7-R7): Changed the application title from "Vite + React" to "Educare".

### Styling Adjustments:

* [`frontend/src/components/sidebar/sidebar.styled.js`](diffhunk://#diff-fe09b2b0564ecd28384e09ad39699d80a980ad7ad869a60a134238b3236b9a5bL7-R7): Modified the sidebar height calculation to `calc(100vh - 90px - 77px)` from `calc(100vh - 90px - 124px)`.